### PR TITLE
Wait for more events after page load

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ var CLEANUP_SCRIPT =
     'chrome.benchmarking.clearPredictorCache();' +
     'chrome.benchmarking.closeConnections();';
 
-var PAGE_DELAY = 1000;
+var PAGE_DELAY = 10000;
 
 function Client(urls, options) {
     var self = this;
@@ -37,6 +37,22 @@ function Client(urls, options) {
                 });
                 // wait its completion before starting with the next user-defined URL
                 var neutralFrameid;
+
+                function endLoadUrlAfterTimeout(value) {
+                    chrome.removeAllListeners('event');
+                    loadUrl(value);
+                }
+                //Function to end the current page load
+                function endLoadUrl(){
+                    common.dump('--- End: ' + url);
+                    self.emit(page.isFailed() ? 'pageError' : 'pageEnd', url);
+                    // start the next URL after a certain delay
+                    // so to "purge" any spurious requests
+                    setTimeout(function () {
+                        endLoadUrlAfterTimeout(index + 1);
+                    }, PAGE_DELAY);
+                }
+
                 chrome.on('event', function (message) {
                     switch (message.method) {
                     case 'Page.frameNavigated':
@@ -77,12 +93,7 @@ function Client(urls, options) {
                                 if (page.isFinished()) {
                                     common.dump('--- End: ' + url);
                                     self.emit(page.isFailed() ? 'pageError' : 'pageEnd', url);
-                                    chrome.removeAllListeners('event');
-                                    // start the next URL after a certain delay
-                                    // so to "purge" any spurious requests
-                                    setTimeout(function () {
-                                        loadUrl(index + 1);
-                                    }, PAGE_DELAY);
+                                    endLoadUrl();
                                 }
                             });
                         }

--- a/lib/har.js
+++ b/lib/har.js
@@ -58,7 +58,10 @@ function fromPage(page) {
         // - timing.requestTime: seconds
         // - timing.*Start/End: milliseconds from the above
         var timing = object.responseMessage.response.timing;
-        timing.requestTime *= 1000; // to ms
+        if (!timing.requestInMs) {
+            timing.requestTime *= 1000; // to ms
+            timing.requestInMs = true;
+        }
         var dnsTime = timingDelta(timing.dnsStart, timing.dnsEnd);
         var connectTime = timingDelta(timing.connectStart, timing.connectEnd);
         var proxyTime = timingDelta(timing.proxyStart, timing.proxyEnd);


### PR DESCRIPTION
This PR is related to #10. PR #16 did not work for me. My propose changes work for the use cases where one wants to track more events than those triggered before the page load. I had to increase the PAGE_DELAY constant. This could probably be a command-line parameter. HTH.