### PR TITLE
Fix 'integer value expected' error when use width and height options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -98,7 +98,7 @@ function postHook(url, client) {
 const {host, port, width, height, content, cache, timeout, retry, retryDelay, postData, parallel} = program;
 CHC.run(program.args, {
     host, port,
-    width, height,
+    width: parseInt(width, 10), height: parseInt(height, 10),
     content,
     cache,
     timeout,


### PR DESCRIPTION
Hello, I got "Invalid parameters (width: integer value expected; height: integer value expected)" error when use --width and/or --height option with Chromium 72.0.3626.119.