### PR TITLE
Log firstContentfulPaint as timing metric

### DIFF
--- a/lib/har.js
+++ b/lib/har.js
@@ -36,6 +36,7 @@ function parsePage(pageId, stats) {
     // page timings
     const onContentLoad = stats.domContentEventFiredMs - stats.firstRequestMs;
     const onLoad = stats.loadEventFiredMs - stats.firstRequestMs;
+    const onPaint = stats.firstContentfulPaintMs;
     // process this page load entries
     const entries = [...stats.entries.values()]
         .map((entry) => parseEntry(pageId, entry))
@@ -48,7 +49,8 @@ function parsePage(pageId, stats) {
             startedDateTime,
             pageTimings: {
                 onContentLoad,
-                onLoad
+                onLoad,
+                onPaint
             },
             _user: stats.user
         },

--- a/lib/live.js
+++ b/lib/live.js
@@ -89,7 +89,7 @@ class Live {
         await Network.enable();
         await Page.enable();
         // register events
-        const stats = new Stats(this._url, this._options);
+        const stats = new Stats(client, this._url, this._options);
         const termination = new Promise((fulfill, reject) => {
             client.on('event', (event) => {
                 stats.processEvent(fulfill, reject, event);

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -55,7 +55,7 @@ class Stats {
                 {expression: "window.performance.getEntriesByName('first-contentful-paint')[0].startTime"}
             )
             this.firstContentfulPaintMs = this.firstContentfulPaintMs.result.value;
-        } catch { }
+        } catch (e) { }
         // check termination condition
         this._checkFinished(fulfill);
     }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -2,7 +2,7 @@
 
 class Stats {
     constructor(client, url, options) {
-        this.client = client
+        this.client = client;
         this._options = options;
         this._responseBodyCounter = 0;
         this.url = url;
@@ -52,8 +52,8 @@ class Stats {
         const {timestamp} = params;
         this.loadEventFiredMs = timestamp * 1000;
         this.firstContentfulPaintMs = await this.client.Runtime.evaluate(
-            {expression: "window.performance.getEntriesByName('first-contentful-paint')[0].startTime"}
-        )
+            {expression: 'window.performance.getEntriesByName("first-contentful-paint")[0].startTime'}
+        );
         this.firstContentfulPaintMs = this.firstContentfulPaintMs.result.value;
         // check termination condition
         this._checkFinished(fulfill);

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,7 +1,8 @@
 'use strict';
 
 class Stats {
-    constructor(url, options) {
+    constructor(client, url, options) {
+        this.client = client
         this._options = options;
         this._responseBodyCounter = 0;
         this.url = url;
@@ -9,6 +10,7 @@ class Stats {
         this.firstRequestMs = undefined;
         this.domContentEventFiredMs = undefined;
         this.loadEventFiredMs = undefined;
+        this.firstContentfulPaintMs = undefined;
         this.entries = new Map();
         this.user = undefined; // filled from outside
     }
@@ -45,9 +47,15 @@ class Stats {
         this._checkFinished(fulfill);
     }
 
-    _Page_loadEventFired(fulfill, reject, params) {
+    async _Page_loadEventFired(fulfill, reject, params) {
         const {timestamp} = params;
         this.loadEventFiredMs = timestamp * 1000;
+        try {
+            this.firstContentfulPaintMs = await this.client.Runtime.evaluate(
+                {expression: "window.performance.getEntriesByName('first-contentful-paint')[0].startTime"}
+            )
+            this.firstContentfulPaintMs = this.firstContentfulPaintMs.result.value;
+        } catch { }
         // check termination condition
         this._checkFinished(fulfill);
     }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -31,6 +31,7 @@ class Stats {
         return this.firstRequestMs &&
             this.domContentEventFiredMs &&
             this.loadEventFiredMs &&
+            this.firstContentfulPaintMs &&
             (!this._options.content || this._responseBodyCounter === 0);
     }
 
@@ -50,12 +51,10 @@ class Stats {
     async _Page_loadEventFired(fulfill, reject, params) {
         const {timestamp} = params;
         this.loadEventFiredMs = timestamp * 1000;
-        try {
-            this.firstContentfulPaintMs = await this.client.Runtime.evaluate(
-                {expression: "window.performance.getEntriesByName('first-contentful-paint')[0].startTime"}
-            )
-            this.firstContentfulPaintMs = this.firstContentfulPaintMs.result.value;
-        } catch (e) { }
+        this.firstContentfulPaintMs = await this.client.Runtime.evaluate(
+            {expression: "window.performance.getEntriesByName('first-contentful-paint')[0].startTime"}
+        )
+        this.firstContentfulPaintMs = this.firstContentfulPaintMs.result.value;
         // check termination condition
         this._checkFinished(fulfill);
     }


### PR DESCRIPTION
firstContentfulPaint is an important performance metric for which the debugger doesn't seem to send a message. Worked around by executing JS in page context.
I'm not very familiar with node, so let me know if I'm breaking any patterns. Thanks